### PR TITLE
fix: upgrade GoAkt to v3.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: go vet ./...
 
       - name: Run tests
-        run: go test --cover -coverpkg=./...  ./... -coverprofile=coverage.txt  -covermode=count
+        run: go test --cover -coverpkg=./...  ./... -coverprofile=coverage.txt  -covermode=count -timeout 0
 #        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tmaxmax/go-sse v0.10.0
-	github.com/tochemey/goakt/v3 v3.2.1
+	github.com/tochemey/goakt/v3 v3.2.2
 	google.golang.org/protobuf v1.36.6
 )
 

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/tidwall/redcon v1.6.2/go.mod h1:p5Wbsgeyi2VSTBWOcA5vRXrOb9arFTcU2+ZzF
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/tmaxmax/go-sse v0.10.0 h1:j9F93WB4Hxt8wUf6oGffMm4dutALvUPoDDxfuDQOSqA=
 github.com/tmaxmax/go-sse v0.10.0/go.mod h1:u/2kZQR1tyngo1lKaNCj1mJmhXGZWS1Zs5yiSOD+Eg8=
-github.com/tochemey/goakt/v3 v3.2.1 h1:qRVnlqSBE4H+WUBRe91gltATF/7nFWDdjtpavdpUFvk=
-github.com/tochemey/goakt/v3 v3.2.1/go.mod h1:QFOZLqQlrsa9hRPuTR8Vzhaguz2AeuKMlxRBUGDfEn8=
+github.com/tochemey/goakt/v3 v3.2.2 h1:S5TRzE7ns+QaZejqX8ag6DvIXvDhmMfsZpYXScmm/Qk=
+github.com/tochemey/goakt/v3 v3.2.2/go.mod h1:+tyW2Of25shYnqnsTwvd+qTL5xZ4g9HKM+RJ183LJM8=
 github.com/tochemey/olric v0.2.2 h1:EfzwBzWK6FBkigSb33Q1lNF+4ytPalyJFY/ozgQp8rQ=
 github.com/tochemey/olric v0.2.2/go.mod h1:+ZSc9y3FKOey3o//qMmafOaHDoPS4I3cqp8cSQP+v38=
 github.com/travisjeffery/go-dynaport v1.0.0 h1:m/qqf5AHgB96CMMSworIPyo1i7NZueRsnwdzdCJ8Ajw=

--- a/pkg/actors/client_connection_actor_test.go
+++ b/pkg/actors/client_connection_actor_test.go
@@ -184,7 +184,7 @@ func TestClientConnectionActor(t *testing.T) {
 	ctx := context.Background()
 	actorSystem, err := actor.NewActorSystem("test-system",
 		actor.WithPassivationDisabled(),
-		actor.WithLogger(logger.DefaultSlogLogger),
+		actor.WithLogger(logger.DiscardSlogLogger),
 	)
 	require.NoError(t, err)
 

--- a/pkg/actors/death_watcher_test.go
+++ b/pkg/actors/death_watcher_test.go
@@ -18,7 +18,7 @@ func TestDeathWatcher(t *testing.T) {
 	ctx := context.Background()
 	actorSystem, err := actor.NewActorSystem("test-system",
 		actor.WithPassivationDisabled(),
-		actor.WithLogger(logger.DefaultSlogLogger),
+		actor.WithLogger(logger.DiscardSlogLogger),
 	)
 	require.NoError(t, err)
 

--- a/pkg/actors/mcp_session_state_machine_test.go
+++ b/pkg/actors/mcp_session_state_machine_test.go
@@ -152,7 +152,7 @@ func TestMcpSessionStateMachine(t *testing.T) {
 	ctx := context.Background()
 	actorSystem, err := actor.NewActorSystem("test-system",
 		actor.WithPassivationDisabled(),
-		actor.WithLogger(logger.DefaultSlogLogger))
+		actor.WithLogger(logger.DiscardSlogLogger))
 	require.NoError(t, err)
 
 	err = actorSystem.Start(ctx)

--- a/pkg/utils/state_machine_actor_test.go
+++ b/pkg/utils/state_machine_actor_test.go
@@ -2,14 +2,16 @@ package utils
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tochemey/goakt/v3/actor"
 	"github.com/tochemey/goakt/v3/log"
+
+	"github.com/traego/scaled-mcp/internal/logger"
 	"github.com/traego/scaled-mcp/pkg/proto/mcppb"
 )
 
@@ -40,7 +42,7 @@ func TestStateMachineActor(t *testing.T) {
 	ctx := context.Background()
 	actorSystem, err := actor.NewActorSystem("test-system",
 		actor.WithPassivationDisabled(),
-		actor.WithLogger(log.DefaultLogger))
+		actor.WithLogger(logger.DiscardSlogLogger))
 	require.NoError(t, err)
 
 	err = actorSystem.Start(ctx)


### PR DESCRIPTION
- Upgrade to GoAkt v3.2.2 due to some go routine leak in the previous version
- Update GHA ci to run tests to avoid timeout