### PR TITLE
Session ID Cookie on GET SSE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/traego/scaled-mcp
 
-go 1.24.2
+go 1.24.4
 
 require (
 	disorder.dev/shandler v0.0.0-20250411134702-523d18ddef40

--- a/internal/actors/mcp_session_state_machine.go
+++ b/internal/actors/mcp_session_state_machine.go
@@ -206,7 +206,7 @@ func handleWrappedRequestUninitialized(rctx *actor.ReceiveContext, sessionData *
 
 	default:
 		// Return error for non-initialize requests in uninitialized state
-		rctx.Logger().Info("mcp session actor got non-lifecycle message before being initialized", "session_id", sessionData.SessionID)
+		rctx.Logger().Info("mcp session actor got non-lifecycle message before being initialized", "session_id", sessionData.SessionID, "method", msg.Request.Method)
 		errorResp := utils.CreateErrorResponse(msg.Request, -32002, "Server not initialized", nil)
 		sendResponse(rctx, ctx, sessionData, msg, errorResp)
 

--- a/internal/channels/channel_test.go
+++ b/internal/channels/channel_test.go
@@ -14,7 +14,7 @@ func TestOneWayChannelInterface(t *testing.T) {
 	r, err := http.NewRequest("GET", "/events", nil)
 	require.NoError(t, err)
 
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	var oneWayChannel OneWayChannel = channel
@@ -38,7 +38,7 @@ func TestSSEChannelImplementation(t *testing.T) {
 	r, err := http.NewRequest("GET", "/events", nil)
 	require.NoError(t, err)
 
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	type TestObject struct {

--- a/internal/channels/sse_channel.go
+++ b/internal/channels/sse_channel.go
@@ -14,12 +14,22 @@ type SSEChannel struct {
 }
 
 // NewSSEChannel creates a new SSE channel from an HTTP response writer and request
-func NewSSEChannel(w http.ResponseWriter, r *http.Request) *SSEChannel {
+func NewSSEChannel(w http.ResponseWriter, r *http.Request, sessionId string) *SSEChannel {
 	// Set up SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Access-Control-Expose-Headers", "Content-Type")
+
+	// Set a secure, HTTP-only cookie containing the session ID so reconnect handlers can retrieve it.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "mcp_session_id",
+		Value:    sessionId,
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
 
 	// Write the HTTP status before any data is written
 	w.WriteHeader(http.StatusOK)

--- a/internal/channels/sse_channel_test.go
+++ b/internal/channels/sse_channel_test.go
@@ -18,7 +18,7 @@ func TestSSEChannel_NewSSEChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	// Verify the headers are set correctly
@@ -43,7 +43,7 @@ func TestSSEChannel_GetDoneChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	// Get the done channel
@@ -64,7 +64,7 @@ func TestSSEChannel_Send_String(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	// Send a string event
@@ -86,7 +86,7 @@ func TestSSEChannel_Send_Object(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	// Create a test object
@@ -118,7 +118,7 @@ func TestSSEChannel_Send_NoEventType(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	// Send an event without an event type
@@ -140,7 +140,7 @@ func TestSSEChannel_SendEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	// Send an endpoint event
@@ -162,7 +162,7 @@ func TestSSEChannel_Send_MarshalError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	// Create an object that will cause a marshal error (circular reference)
@@ -186,7 +186,7 @@ func TestSSEChannel_Interface(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r)
+	channel := NewSSEChannel(w, r, "test-session")
 	require.NotNil(t, channel)
 
 	// Verify that the channel implements the OneWayChannel interface

--- a/internal/httphandlers/mcp_get_handler.go
+++ b/internal/httphandlers/mcp_get_handler.go
@@ -27,7 +27,7 @@ func (h *MCPHandler) HandleMCPGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create an SSE channel for communication
-	channel := channels.NewSSEChannel(w, r)
+	channel := channels.NewSSEChannel(w, r, sessionId)
 
 	cca := actors2.NewClientConnectionActor(h.config, sessionId, nil, channel, true, false, "")
 	clientActorName := fmt.Sprintf("%s-client", sessionId)

--- a/internal/httphandlers/sse_get_handler.go
+++ b/internal/httphandlers/sse_get_handler.go
@@ -2,10 +2,11 @@ package httphandlers
 
 import (
 	"fmt"
+	"net/http"
+
 	actors2 "github.com/traego/scaled-mcp/internal/actors"
 	"github.com/traego/scaled-mcp/internal/channels"
 	"github.com/traego/scaled-mcp/pkg/utils"
-	"net/http"
 )
 
 func (h *MCPHandler) SSEGetWithBasePath(basePath string) http.HandlerFunc {
@@ -23,22 +24,39 @@ func (h *MCPHandler) SSEGetFunc(w http.ResponseWriter, r *http.Request, basePath
 	// I think this is easy...spin up the death watcher, spin up the connection watcher, wait for death to come
 	ctx := r.Context() // TODO Add logging details around these
 
-	sessionId, err := utils.GenerateSecureID(20)
-	if err != nil {
-		handleError(w, err, "")
-		return
+	// err will be reused throughout this function
+	var err error
+
+	// Attempt to retrieve the session ID from cookie (set during initial connection)
+	var sessionId string
+	cookie, cerr := r.Cookie("mcp_session_id")
+	if cerr == nil && cookie != nil && cookie.Value != "" {
+		sessionId = cookie.Value
+	} else {
+		// Fallback to generating a fresh secure session ID
+		var gerr error
+		sessionId, gerr = utils.GenerateSecureID(20)
+		if gerr != nil {
+			handleError(w, gerr, "")
+			return
+		}
 	}
 
-	sa := actors2.NewMcpSessionStateMachine(h.serverInfo, sessionId)
 	san := utils.GetSessionActorName(sessionId)
-	_, err = h.actorSystem.Spawn(ctx, san, sa)
-	if err != nil {
-		handleError(w, err, "")
-		return
+
+	// Ensure the session actor exists; spawn only if we don't find it running
+	_, existingPid, _ := h.actorSystem.ActorOf(ctx, san)
+	if existingPid == nil {
+		sa := actors2.NewMcpSessionStateMachine(h.serverInfo, sessionId)
+		_, err = h.actorSystem.Spawn(ctx, san, sa)
+		if err != nil {
+			handleError(w, err, "")
+			return
+		}
 	}
 
 	// Create an SSE channel for communication
-	channel := channels.NewSSEChannel(w, r)
+	channel := channels.NewSSEChannel(w, r, sessionId)
 
 	cca := actors2.NewClientConnectionActor(h.config, sessionId, nil, channel, true, true, basePath)
 	clientActorName := fmt.Sprintf("%s-client", sessionId)


### PR DESCRIPTION
This solves an issues that we ran into in a production deployment - the prod load balancers kill the SSE connection after about 45 seconds, which triggers the sdk to reconnect, but the reconnect doesn't bring any information to reconnect to the existing session. This adds a cookie so we reconnect to the same session on the n+1 get sse