### PR TITLE
Major Change: Vastly Improved Session ID Support

### DIFF
--- a/internal/actors/mcp_session_state_machine_test.go
+++ b/internal/actors/mcp_session_state_machine_test.go
@@ -3,6 +3,7 @@ package actors
 import (
 	"context"
 	"encoding/json"
+	"github.com/traego/scaled-mcp/pkg/session"
 	"testing"
 	"time"
 
@@ -112,6 +113,10 @@ func (s *TestServerInfo) GetAuthHandler() config.AuthHandler {
 }
 
 func (s *TestServerInfo) GetTraceHandler() config.TraceHandler {
+	return nil
+}
+
+func (s *TestServerInfo) GetSessionManager() session.SessionManager {
 	return nil
 }
 

--- a/internal/channels/channel_test.go
+++ b/internal/channels/channel_test.go
@@ -14,7 +14,7 @@ func TestOneWayChannelInterface(t *testing.T) {
 	r, err := http.NewRequest("GET", "/events", nil)
 	require.NoError(t, err)
 
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, true)
 	require.NotNil(t, channel)
 
 	var oneWayChannel OneWayChannel = channel
@@ -38,7 +38,7 @@ func TestSSEChannelImplementation(t *testing.T) {
 	r, err := http.NewRequest("GET", "/events", nil)
 	require.NoError(t, err)
 
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	type TestObject struct {

--- a/internal/channels/sse_channel.go
+++ b/internal/channels/sse_channel.go
@@ -15,24 +15,26 @@ type SSEChannel struct {
 }
 
 // NewSSEChannel creates a new SSE channel from an HTTP response writer and request
-func NewSSEChannel(w http.ResponseWriter, r *http.Request, sessionId string, secure bool) *SSEChannel {
-	// Set a session cookie on the channel
-	var sameSite http.SameSite
-	if secure {
-		sameSite = http.SameSiteNoneMode
-	} else {
-		sameSite = http.SameSiteLaxMode
-	}
+func NewSSEChannel(w http.ResponseWriter, r *http.Request, sessionId string, secure bool, setCookie bool) *SSEChannel {
+	if setCookie {
+		// Set a session cookie on the channel
+		var sameSite http.SameSite
+		if secure {
+			sameSite = http.SameSiteNoneMode
+		} else {
+			sameSite = http.SameSiteLaxMode
+		}
 
-	http.SetCookie(w, &http.Cookie{
-		Name:     "session_id",
-		Value:    sessionId,
-		Path:     "/",
-		Expires:  time.Now().Add(1 * time.Hour),
-		HttpOnly: true,
-		Secure:   secure,
-		SameSite: sameSite,
-	})
+		http.SetCookie(w, &http.Cookie{
+			Name:     "session_id",
+			Value:    sessionId,
+			Path:     "/",
+			Expires:  time.Now().Add(1 * time.Hour),
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: sameSite,
+		})
+	}
 
 	// Set up SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/channels/sse_channel_test.go
+++ b/internal/channels/sse_channel_test.go
@@ -18,7 +18,7 @@ func TestSSEChannel_NewSSEChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	// Verify the headers are set correctly
@@ -43,7 +43,7 @@ func TestSSEChannel_GetDoneChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	// Get the done channel
@@ -64,7 +64,7 @@ func TestSSEChannel_Send_String(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	// Send a string event
@@ -86,7 +86,7 @@ func TestSSEChannel_Send_Object(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	// Create a test object
@@ -118,7 +118,7 @@ func TestSSEChannel_Send_NoEventType(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	// Send an event without an event type
@@ -140,7 +140,7 @@ func TestSSEChannel_SendEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	// Send an endpoint event
@@ -162,7 +162,7 @@ func TestSSEChannel_Send_MarshalError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	// Create an object that will cause a marshal error (circular reference)
@@ -186,7 +186,7 @@ func TestSSEChannel_Interface(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new SSE channel
-	channel := NewSSEChannel(w, r, "test-session", false)
+	channel := NewSSEChannel(w, r, "test-session", false, false)
 	require.NotNil(t, channel)
 
 	// Verify that the channel implements the OneWayChannel interface

--- a/internal/executors/prompt_executor_test.go
+++ b/internal/executors/prompt_executor_test.go
@@ -3,6 +3,7 @@ package executors
 import (
 	"context"
 	"encoding/json"
+	"github.com/traego/scaled-mcp/pkg/session"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,6 +85,10 @@ func (s *TestPromptServerInfo) GetAuthHandler() config.AuthHandler {
 }
 
 func (s *TestPromptServerInfo) GetTraceHandler() config.TraceHandler {
+	return nil
+}
+
+func (s *TestPromptServerInfo) GetSessionManager() session.SessionManager {
 	return nil
 }
 

--- a/internal/executors/resource_executor_test.go
+++ b/internal/executors/resource_executor_test.go
@@ -3,6 +3,7 @@ package executors
 import (
 	"context"
 	"encoding/json"
+	"github.com/traego/scaled-mcp/pkg/session"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,6 +90,10 @@ func (s *TestResourceServerInfo) GetAuthHandler() config.AuthHandler {
 }
 
 func (s *TestResourceServerInfo) GetTraceHandler() config.TraceHandler {
+	return nil
+}
+
+func (s *TestResourceServerInfo) GetSessionManager() session.SessionManager {
 	return nil
 }
 

--- a/internal/executors/tool_executor_test.go
+++ b/internal/executors/tool_executor_test.go
@@ -3,6 +3,7 @@ package executors
 import (
 	"context"
 	"encoding/json"
+	"github.com/traego/scaled-mcp/pkg/session"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -108,6 +109,10 @@ func (s *TestServerInfo) GetAuthHandler() config.AuthHandler {
 }
 
 func (s *TestServerInfo) GetTraceHandler() config.TraceHandler {
+	return nil
+}
+
+func (s *TestServerInfo) GetSessionManager() session.SessionManager {
 	return nil
 }
 

--- a/internal/executors/utilities_executor_test.go
+++ b/internal/executors/utilities_executor_test.go
@@ -3,6 +3,7 @@ package executors
 import (
 	"context"
 	"encoding/json"
+	"github.com/traego/scaled-mcp/pkg/session"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,10 @@ func (s *TestUtilitiesServerInfo) GetAuthHandler() config.AuthHandler {
 }
 
 func (s *TestUtilitiesServerInfo) GetTraceHandler() config.TraceHandler {
+	return nil
+}
+
+func (s *TestUtilitiesServerInfo) GetSessionManager() session.SessionManager {
 	return nil
 }
 

--- a/internal/httphandlers/mcp_get_handler.go
+++ b/internal/httphandlers/mcp_get_handler.go
@@ -27,7 +27,7 @@ func (h *MCPHandler) HandleMCPGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create an SSE channel for communication
-	channel := channels.NewSSEChannel(w, r, sessionId, h.config.HTTP.SSLEnabled)
+	channel := channels.NewSSEChannel(w, r, sessionId, h.config.HTTP.SSLEnabled, false)
 
 	cca := actors2.NewClientConnectionActor(h.config, sessionId, nil, channel, false, false, "")
 	clientActorName := fmt.Sprintf("%s-client", sessionId)

--- a/internal/httphandlers/mcp_handler_test.go
+++ b/internal/httphandlers/mcp_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/traego/scaled-mcp/pkg/session"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -313,6 +314,10 @@ func (m *mockServerInfo) GetAuthHandler() config.AuthHandler {
 }
 
 func (m *mockServerInfo) GetTraceHandler() config.TraceHandler {
+	return nil
+}
+
+func (m *mockServerInfo) GetSessionManager() session.SessionManager {
 	return nil
 }
 

--- a/internal/httphandlers/mcp_post_handler.go
+++ b/internal/httphandlers/mcp_post_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/traego/scaled-mcp/internal/actors"
 	"github.com/traego/scaled-mcp/pkg/auth"
+	"google.golang.org/protobuf/proto"
 	"log/slog"
 	"net/http"
 
@@ -43,8 +44,22 @@ func (h *MCPHandler) HandleMCPPost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *MCPHandler) handleMcpMessages(ctx context.Context, sessionId string, w http.ResponseWriter, r *http.Request, mr McpRequest) {
+	ai := auth.GetAuthInfo(ctx)
+	var principalId *string
+	if ai != nil {
+		p := ai.GetPrincipalId()
+		principalId = &p
+	}
+
+	err := h.serverInfo.GetSessionManager().VerifySessionId(sessionId, principalId)
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
 	if !mr.IsBatch {
-		protoMsg, err := protocol.ConvertJSONToProtoRequest(mr.Message)
+		var protoMsg *mcppb.JsonRpcRequest
+		protoMsg, err = protocol.ConvertJSONToProtoRequest(mr.Message)
 		if err != nil {
 			handleError(w, err, mr.Message.ID)
 			return
@@ -59,15 +74,17 @@ func (h *MCPHandler) handleMcpMessages(ctx context.Context, sessionId string, w 
 			TraceId:               utils.GetTraceId(ctx),
 		}
 
-		if ai := auth.GetAuthInfo(ctx); ai != nil && h.serverInfo.GetAuthHandler() != nil {
-			ser, err := h.serverInfo.GetAuthHandler().Serialize(ai)
+		if ai != nil && h.serverInfo.GetAuthHandler() != nil {
+			var ser []byte
+			ser, err = h.serverInfo.GetAuthHandler().Serialize(ai)
 			if err != nil {
 				handleError(w, fmt.Errorf("unable to serialize auth"), mr.Message.ID)
 			}
 			wrapped.AuthInfo = ser
 		}
 
-		_, rid, err := h.actorSystem.ActorOf(ctx, "root")
+		var rid *actor.PID
+		_, rid, err = h.actorSystem.ActorOf(ctx, "root")
 		if err != nil {
 			handleError(w, err, mr.Message.ID)
 		}
@@ -82,7 +99,8 @@ func (h *MCPHandler) handleMcpMessages(ctx context.Context, sessionId string, w 
 			w.WriteHeader(http.StatusAccepted)
 			return
 		} else {
-			respMsg, err := rid.SendSync(ctx, san, &wrapped, h.config.RequestTimeout)
+			var respMsg proto.Message
+			respMsg, err = rid.SendSync(ctx, san, &wrapped, h.config.RequestTimeout)
 			if err != nil {
 				handleError(w, err, mr.Message.ID)
 				return
@@ -90,11 +108,13 @@ func (h *MCPHandler) handleMcpMessages(ctx context.Context, sessionId string, w 
 
 			rjm, ok := respMsg.(*mcppb.JsonRpcResponse)
 			if !ok {
-				err := actor.NewInternalError(fmt.Errorf("failed to parse json-rpc response type"))
+				err = actor.NewInternalError(fmt.Errorf("failed to parse json-rpc response type"))
 				handleError(w, err, mr.Message.ID)
 				return
 			}
-			rm, err := protocol.ConvertProtoToJSONResponse(rjm)
+
+			var rm protocol.JSONRPCMessage
+			rm, err = protocol.ConvertProtoToJSONResponse(rjm)
 			if err != nil {
 				handleError(w, err, mr.Message.ID)
 				return
@@ -108,13 +128,19 @@ func (h *MCPHandler) handleMcpMessages(ctx context.Context, sessionId string, w 
 			return
 		}
 	} else {
-		err := actor.NewInternalError(fmt.Errorf("batch messaging not implemented"))
+		err = actor.NewInternalError(fmt.Errorf("batch messaging not implemented"))
 		handleError(w, err, mr.Message.ID)
 		return
 	}
 }
 
 func (h *MCPHandler) handleMcpInitDemand(ctx context.Context, w http.ResponseWriter, r *http.Request, mr McpRequest) {
+	ai := auth.GetAuthInfo(ctx)
+	var principalId *string
+	if ai != nil {
+		p := ai.GetPrincipalId()
+		principalId = &p
+	}
 	// If no session and it's a post, check that it's an initialize message. If it's not, it's a bad request
 	if mr.IsBatch {
 		slog.Debug("Received batch request without sessionId (expecting single initialize message")
@@ -124,9 +150,9 @@ func (h *MCPHandler) handleMcpInitDemand(ctx context.Context, w http.ResponseWri
 	} else {
 		msg := mr.Message
 		if msg.Method == "initialize" {
-			sessionId, err := utils.GenerateSecureID(20)
+			sessionId, err := h.serverInfo.GetSessionManager().GenerateSessionId(principalId)
 			if err != nil {
-				handleError(w, err, msg.ID)
+				handleError(w, err, mr.Message.ID)
 				return
 			}
 
@@ -151,7 +177,7 @@ func (h *MCPHandler) handleMcpInitDemand(ctx context.Context, w http.ResponseWri
 				TraceId:               utils.GetTraceId(ctx),
 			}
 
-			if ai := auth.GetAuthInfo(ctx); ai != nil && h.serverInfo.GetAuthHandler() != nil {
+			if ai != nil && h.serverInfo.GetAuthHandler() != nil {
 				ser, err := h.serverInfo.GetAuthHandler().Serialize(ai)
 				if err != nil {
 					handleError(w, fmt.Errorf("unable to serialize auth"), mr.Message.ID)

--- a/internal/httphandlers/message_post_handler.go
+++ b/internal/httphandlers/message_post_handler.go
@@ -2,6 +2,7 @@ package httphandlers
 
 import (
 	"fmt"
+	"github.com/tochemey/goakt/v3/actor"
 	"github.com/traego/scaled-mcp/pkg/auth"
 	"github.com/traego/scaled-mcp/pkg/proto/mcppb"
 	"net/http"
@@ -21,6 +22,25 @@ Route Message to Session Actor
 func (h *MCPHandler) HandleMessagePost(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	sessionId := r.URL.Query().Get("sessionId")
+
+	if sessionId == "" {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("session not found"))
+		return
+	}
+
+	ai := auth.GetAuthInfo(ctx)
+	var principalId *string
+	if ai != nil {
+		p := ai.GetPrincipalId()
+		principalId = &p
+	}
+
+	err := h.serverInfo.GetSessionManager().VerifySessionId(sessionId, principalId)
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
 
 	mcpRequest, err := parseMessageRequest(r)
 	if err != nil {
@@ -50,15 +70,17 @@ func (h *MCPHandler) HandleMessagePost(w http.ResponseWriter, r *http.Request) {
 		TraceId:               utils.GetTraceId(ctx),
 	}
 
-	if ai := auth.GetAuthInfo(ctx); ai != nil && h.serverInfo.GetAuthHandler() != nil {
-		ser, err := h.serverInfo.GetAuthHandler().Serialize(ai)
+	if ai != nil && h.serverInfo.GetAuthHandler() != nil {
+		var ser []byte
+		ser, err = h.serverInfo.GetAuthHandler().Serialize(ai)
 		if err != nil {
 			handleError(w, fmt.Errorf("unable to serialize auth"), mcpRequest.Message.ID)
 		}
 		wrapped.AuthInfo = ser
 	}
 
-	_, rid, err := h.actorSystem.ActorOf(ctx, "root")
+	var rid *actor.PID
+	_, rid, err = h.actorSystem.ActorOf(ctx, "root")
 	if err != nil {
 		handleError(w, err, mcpRequest)
 		return

--- a/internal/httphandlers/sse_get_handler.go
+++ b/internal/httphandlers/sse_get_handler.go
@@ -1,10 +1,13 @@
 package httphandlers
 
 import (
+	"encoding/json"
 	"fmt"
 	actors2 "github.com/traego/scaled-mcp/internal/actors"
 	"github.com/traego/scaled-mcp/internal/channels"
+	"github.com/traego/scaled-mcp/pkg/auth"
 	"github.com/traego/scaled-mcp/pkg/utils"
+	"log/slog"
 	"net/http"
 )
 
@@ -19,9 +22,63 @@ func (h *MCPHandler) HandleSSEGet(w http.ResponseWriter, r *http.Request) {
 	h.SSEGetFunc(w, r, "")
 }
 
+func (h *MCPHandler) HandleSessionPreFlight(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Set appropriate headers for the response
+	w.Header().Set("Content-Type", "application/json")
+
+	// If we don't have a session manager initialized, return an error
+	if h.serverInfo.GetSessionManager() == nil {
+		slog.Error("session manager not initialized")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	var uniqueId *string
+	if ai := auth.GetAuthInfo(ctx); ai != nil && h.serverInfo.GetAuthHandler() != nil {
+		uid := ai.GetPrincipalId()
+		uniqueId = &uid
+	}
+
+	// Generate a secure signed session ID that includes a random component and a signature
+	sessionID, err := h.serverInfo.GetSessionManager().GenerateSessionId(uniqueId)
+	if err != nil {
+		slog.Error("failed to generate session ID", slog.Any("error", err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Return the session ID in a JSON response
+	response := map[string]string{
+		"sessionId": sessionID,
+	}
+
+	// Convert the response to JSON
+	jsonResponse, err := json.Marshal(response)
+	if err != nil {
+		slog.Error("failed to marshal response", slog.Any("error", err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Write the response
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(jsonResponse)
+	if err != nil {
+		slog.Error("failed to write response", slog.Any("error", err))
+	}
+}
+
 func (h *MCPHandler) SSEGetFunc(w http.ResponseWriter, r *http.Request, basePath string) {
 	// I think this is easy...spin up the death watcher, spin up the connection watcher, wait for death to come
 	ctx := r.Context() // TODO Add logging details around these
+
+	var uniqueId *string
+	if ai := auth.GetAuthInfo(ctx); ai != nil && h.serverInfo.GetAuthHandler() != nil {
+		uid := ai.GetPrincipalId()
+		uniqueId = &uid
+	}
 
 	// To read the session_id cookie
 	cookie, err := r.Cookie("session_id")
@@ -30,12 +87,27 @@ func (h *MCPHandler) SSEGetFunc(w http.ResponseWriter, r *http.Request, basePath
 		return
 	}
 
+	setCookie := true
+
 	var sessionId string
 	if cookie == nil {
-		sessionId, err = utils.GenerateSecureID(20)
-		if err != nil {
-			handleError(w, err, "")
-			return
+		if r.URL.Query().Get("sessionId") != "" {
+			// If session ID is provided in the query string, verify it's a valid signed ID
+			sessionId = r.URL.Query().Get("sessionId")
+
+			// Verify the signed session ID with a 15-minute max age
+			err = h.serverInfo.GetSessionManager().VerifySessionId(sessionId, uniqueId)
+			if err != nil {
+				http.Error(w, "Access denied", http.StatusForbidden)
+			}
+			// Use the verified random ID component
+			setCookie = false
+		} else {
+			sessionId, err = h.serverInfo.GetSessionManager().GenerateSessionId(uniqueId)
+			if err != nil {
+				handleError(w, err, "")
+				return
+			}
 		}
 	} else {
 		sessionId = cookie.Value
@@ -55,7 +127,7 @@ func (h *MCPHandler) SSEGetFunc(w http.ResponseWriter, r *http.Request, basePath
 	}
 
 	// Create an SSE channel for communication
-	channel := channels.NewSSEChannel(w, r, sessionId, h.config.HTTP.SSLEnabled)
+	channel := channels.NewSSEChannel(w, r, sessionId, h.config.HTTP.SSLEnabled, setCookie)
 
 	clientId, err := utils.GenerateSecureID(20)
 	if err != nil {

--- a/pkg/client/http_client.go
+++ b/pkg/client/http_client.go
@@ -693,6 +693,9 @@ func (c *httpClient) createNotificationRequest(ctx context.Context, endpoint str
 	// Set headers - notifications only need JSON response
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
 
 	// Add session ID if we have one
 	c.sessionIdMutex.Lock()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -141,6 +141,9 @@ type SessionConfig struct {
 
 	// Key prefix for session storage
 	KeyPrefix string `json:"key_prefix"`
+
+	// Secret used for signing session IDs (used for reconnection security)
+	SessionIDSecret string `json:"session_id_secret"`
 }
 
 // RedisConfig holds the Redis configuration
@@ -203,6 +206,7 @@ func DefaultConfig() *ServerConfig {
 			TTL:               5 * time.Minute,
 			UseInMemory:       true,
 			KeyPrefix:         "mcp:session:",
+			SessionIDSecret:   "",
 		},
 		Actor: ActorConfig{
 			NumWorkers:      10,

--- a/pkg/config/mcp_server_info.go
+++ b/pkg/config/mcp_server_info.go
@@ -6,6 +6,7 @@ import (
 	"github.com/traego/scaled-mcp/pkg/proto/mcppb"
 	"github.com/traego/scaled-mcp/pkg/protocol"
 	"github.com/traego/scaled-mcp/pkg/resources"
+	"github.com/traego/scaled-mcp/pkg/session"
 	"net/http"
 )
 
@@ -16,6 +17,7 @@ type McpServerInfo interface {
 	GetExecutors() MethodHandler
 	GetAuthHandler() AuthHandler
 	GetTraceHandler() TraceHandler
+	GetSessionManager() session.SessionManager
 }
 
 type AuthHandler interface {

--- a/pkg/server/mcp_server.go
+++ b/pkg/server/mcp_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/traego/scaled-mcp/pkg/session"
 	"log/slog"
 	"net/http"
 	"runtime/debug"
@@ -55,6 +56,8 @@ type McpServer struct {
 	authHandler config.AuthHandler
 
 	traceHandler config.TraceHandler
+
+	sessionManager session.SessionManager
 }
 
 func (s *McpServer) GetExecutors() config.MethodHandler {
@@ -81,6 +84,10 @@ func (s *McpServer) GetServerCapabilities() protocol.ServerCapabilities {
 	return s.serverCapabilities
 }
 
+func (s *McpServer) GetSessionManager() session.SessionManager {
+	return s.sessionManager
+}
+
 // GetActorSystem returns the actor system used by the server
 func (s *McpServer) GetActorSystem() actor.ActorSystem {
 	return s.actorSystem
@@ -92,6 +99,10 @@ func (s *McpServer) HandleMCPGetExternal() http.Handler {
 
 func (s *McpServer) HandleMCPPostExternal() http.Handler {
 	return s.traceHandlerMiddleware(s.authHandlerMiddleware(http.HandlerFunc(s.Handlers.HandleMCPPost)))
+}
+
+func (s *McpServer) HandleSessionPreflightExternal() http.Handler {
+	return s.traceHandlerMiddleware(s.authHandlerMiddleware(http.HandlerFunc(s.Handlers.HandleSessionPreFlight)))
 }
 
 func (s *McpServer) HandleSSEGetExternal(basePath string) http.Handler {
@@ -233,6 +244,18 @@ func NewMcpServer(cfg *config.ServerConfig, options ...McpServerOption) (*McpSer
 		opt(server)
 	}
 
+	if server.sessionManager == nil {
+		var secret string
+		if cfg.Session.SessionIDSecret != "" {
+			secret = cfg.Session.SessionIDSecret
+			slog.Info("Using configured session ID secret")
+		} else {
+			// Generate a random secret for session signing
+			secret = utils.MustGenerateSecureID(32)
+		}
+		server.sessionManager = session.NewSignedStatelessSessionManager(secret)
+	}
+
 	if server.executors == nil {
 		server.executors = executors.DefaultExecutors(server, nil)
 	}
@@ -255,7 +278,7 @@ func NewMcpServer(cfg *config.ServerConfig, options ...McpServerOption) (*McpSer
 		slog.Info("Using default static resource registry")
 	}
 
-	// Create the MCP handler
+	// Create the MCP handler with the session manager
 	server.Handlers = httphandlers.NewMCPHandler(cfg, actorSystem, server)
 
 	// Create the internal handler

--- a/pkg/server/mcp_server_2025_test.go
+++ b/pkg/server/mcp_server_2025_test.go
@@ -18,8 +18,8 @@ import (
 // TestMCPServer2025 tests the MCP server with the 2025 spec.
 func TestMCPServer2025(t *testing.T) {
 	// Get a random available port
-	port, err := testutils.GetAvailablePort()
-	require.NoError(t, err, "Failed to get available port")
+	port, errOuter := testutils.GetAvailablePort()
+	require.NoError(t, errOuter, "Failed to get available port")
 
 	// Create a server config with 2025 compatibility (default)
 	cfg := config.DefaultConfig()
@@ -27,25 +27,25 @@ func TestMCPServer2025(t *testing.T) {
 	cfg.HTTP.Port = port
 
 	registry := resources.NewStaticToolRegistry()
-	err = registry.RegisterTool(protocol.Tool{
+	errOuter = registry.RegisterTool(protocol.Tool{
 		Name:        "Amazing Tool",
 		Description: "Does amazing things",
 		InputSchema: protocol.InputSchema{},
 	}, func(ctx context.Context, params map[string]interface{}) (interface{}, error) {
 		return nil, nil
 	})
-	require.NoError(t, err)
+	require.NoError(t, errOuter)
 
 	// Create a new MCP server
-	mcpServer, err := NewMcpServer(cfg, WithToolRegistry(registry))
-	require.NoError(t, err, "Failed to create MCP server")
+	mcpServer, errOuter := NewMcpServer(cfg, WithToolRegistry(registry))
+	require.NoError(t, errOuter, "Failed to create MCP server")
 
 	// Start the server
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err = mcpServer.Start(ctx)
-	require.NoError(t, err, "Failed to start MCP server")
+	errOuter = mcpServer.Start(ctx)
+	require.NoError(t, errOuter, "Failed to start MCP server")
 
 	defer cancel()
 	// Ensure server is stopped after the test

--- a/pkg/session/session_manager.go
+++ b/pkg/session/session_manager.go
@@ -1,0 +1,48 @@
+package session
+
+import "errors"
+
+type SessionManager interface {
+	// GenerateSessionId creates a session id, using the principalId from the optional Auth handler
+	GenerateSessionId(principalId *string) (string, error)
+	VerifySessionId(sessionId string, checkPrincipalId *string) error
+
+	CanSaveSession() bool
+	SaveSession(sessionId string, sessionData interface{}) error
+	LoadSession(sessionId string, checkUniqueId *string) (interface{}, error)
+}
+
+var (
+	ErrSessionStateNotFound = errors.New("session state not found")
+)
+
+func NewErrSessionInvalid(reason string) *ErrSessionInvalid {
+	return &ErrSessionInvalid{
+		Reason: reason,
+	}
+}
+
+// NewErrSessionInvalidWrap creates a new ErrSessionInvalid that wraps another error
+func NewErrSessionInvalidWrap(reason string, wrapped error) *ErrSessionInvalid {
+	return &ErrSessionInvalid{
+		Reason:  reason,
+		wrapped: wrapped,
+	}
+}
+
+type ErrSessionInvalid struct {
+	Reason  string
+	wrapped error
+}
+
+func (e *ErrSessionInvalid) Error() string {
+	if e.wrapped != nil {
+		return "session invalid: " + e.Reason + ": " + e.wrapped.Error()
+	}
+	return "session invalid: " + e.Reason
+}
+
+// Unwrap returns the wrapped error, if any
+func (e *ErrSessionInvalid) Unwrap() error {
+	return e.wrapped
+}

--- a/pkg/session/stateless_session_manager.go
+++ b/pkg/session/stateless_session_manager.go
@@ -1,0 +1,105 @@
+package session
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/traego/scaled-mcp/pkg/utils"
+	"strings"
+)
+
+const DELIMITER = "_"
+
+// SessionIDManager handles creating and verifying secure session IDs
+type SignedStatelessSessionManager struct {
+	secret []byte
+}
+
+func (sm *SignedStatelessSessionManager) CanSaveSession() bool {
+	return false
+}
+
+func (sm *SignedStatelessSessionManager) SaveSession(sessionId string, sessionData interface{}) error {
+	return errors.New("stateless_session_manager does not support saving sessions")
+}
+
+func (sm *SignedStatelessSessionManager) LoadSession(sessionId string, checkUniqueId *string) (interface{}, error) {
+	return nil, ErrSessionStateNotFound
+}
+
+// NewSessionIDManager creates a new session ID manager with the provided secret
+func NewSignedStatelessSessionManager(secret string) SessionManager {
+	return &SignedStatelessSessionManager{
+		secret: []byte(secret),
+	}
+}
+
+// GenerateSessionID creates a signed session ID with format:
+// [random_id].[timestamp].[signature]
+// The signature is an HMAC-SHA256 of the random_id and timestamp
+func (sm *SignedStatelessSessionManager) GenerateSessionId(uniqueCallerId *string) (string, error) {
+	length := 16
+	// Generate random ID
+	randomId, err := utils.GenerateSecureID(length)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate random ID: %w", err)
+	}
+
+	baseStr := getBaseSessionStr(randomId, uniqueCallerId)
+
+	// Generate signature
+	h := hmac.New(sha256.New, sm.secret)
+	h.Write([]byte(baseStr))
+	signature := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+
+	// Combine all parts
+	fullStr := fmt.Sprintf("%s%s%s", baseStr, DELIMITER, signature)
+	return fullStr, nil
+}
+
+func getBaseSessionStr(randomId string, uniqueId *string) string {
+	var uid string
+	if uniqueId == nil {
+		uid = ""
+	} else {
+		uid = *uniqueId
+	}
+	return fmt.Sprintf("%s%s%s", randomId, DELIMITER, uid)
+}
+
+// VerifySessionId checks if a session ID is valid and not expired
+func (sm *SignedStatelessSessionManager) VerifySessionId(sessionId string, checkUniqueId *string) error {
+	parts := strings.SplitN(sessionId, DELIMITER, 3)
+	if len(parts) < 2 {
+		return NewErrSessionInvalid("unexpected shape of session id")
+	}
+
+	var randomId string
+	var providedSig string
+	var uniqueId *string
+	randomId = parts[0]
+	if parts[1] != "" {
+		uniqueId = &parts[1]
+	}
+	providedSig = parts[2]
+
+	if checkUniqueId != nil {
+		if uniqueId == nil || *uniqueId != *checkUniqueId {
+			return NewErrSessionInvalid("unique caller ID mismatch")
+		}
+	}
+
+	// Verify signature
+	baseStr := getBaseSessionStr(randomId, uniqueId)
+	h := hmac.New(sha256.New, sm.secret)
+	h.Write([]byte(baseStr))
+	expectedSig := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+
+	if expectedSig != providedSig {
+		return NewErrSessionInvalid("invalid signature")
+	}
+
+	return nil
+}

--- a/pkg/session/stateless_session_manager_test.go
+++ b/pkg/session/stateless_session_manager_test.go
@@ -1,0 +1,203 @@
+package session
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestNewSessionIDManager(t *testing.T) {
+	// Test with empty secret
+	mgr1 := NewSignedStatelessSessionManager("")
+	if mgr1 == nil {
+		t.Fatal("NewSessionIDManager returned nil for empty secret")
+	}
+	assert.False(t, mgr1.CanSaveSession())
+}
+
+func TestGenerateSignedSessionID(t *testing.T) {
+	const testSecret = "test-secret-key"
+	mgr := NewSignedStatelessSessionManager(testSecret)
+
+	// Test with various lengths
+	testCases := []struct {
+		name      string
+		uniqueId  *string
+		expectErr bool
+	}{
+		{
+			name:      "Standard length without uniqueId",
+			uniqueId:  nil,
+			expectErr: false,
+		},
+		{
+			name:      "With uniqueId",
+			uniqueId:  stringPtr("user123"),
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionID, err := mgr.GenerateSessionId(tc.uniqueId)
+
+			// Check error expectation
+			if (err != nil) != tc.expectErr {
+				t.Errorf("Expected error %v, got %v", tc.expectErr, err != nil)
+				return
+			}
+
+			if err != nil {
+				// Expected error case
+				return
+			}
+
+			// Verify the signature
+			err = mgr.VerifySessionId(sessionID, tc.uniqueId)
+			if err != nil {
+				t.Errorf("Generated session ID failed verification: %v", err)
+			}
+		})
+	}
+
+	// Test with very long uniqueId
+	longUniqueId := strings.Repeat("a", 1000)
+	_, err := mgr.GenerateSessionId(&longUniqueId)
+	if err != nil {
+		t.Errorf("Failed to generate session ID with long uniqueId: %v", err)
+	}
+}
+
+func TestVerifySessionId(t *testing.T) {
+	const testSecret = "test-verification-secret"
+	mgr := NewSignedStatelessSessionManager(testSecret)
+
+	// Generate a valid session ID first
+	uniqueId := "user456"
+	validSessionID, err := mgr.GenerateSessionId(&uniqueId)
+	if err != nil {
+		t.Fatalf("Failed to generate session ID: %v", err)
+	}
+
+	// Generate a session ID without uniqueId
+	validSessionIDNoUnique, err := mgr.GenerateSessionId(nil)
+	if err != nil {
+		t.Fatalf("Failed to generate session ID without uniqueId: %v", err)
+	}
+
+	// Create a different manager with a different secret
+	differentMgr := NewSignedStatelessSessionManager("different-secret")
+
+	testCases := []struct {
+		name          string
+		sessionID     string
+		checkUniqueId *string
+		expectValid   bool
+	}{
+		{
+			name:          "Valid session ID with matching uniqueId check",
+			sessionID:     validSessionID,
+			checkUniqueId: &uniqueId,
+			expectValid:   true,
+		},
+		{
+			name:          "Valid session ID without uniqueId check",
+			sessionID:     validSessionID,
+			checkUniqueId: nil,
+			expectValid:   true,
+		},
+		{
+			name:          "Valid session ID with wrong uniqueId check",
+			sessionID:     validSessionID,
+			checkUniqueId: stringPtr("wronguser"),
+			expectValid:   false,
+		},
+		{
+			name:          "Valid session without uniqueId but with uniqueId check",
+			sessionID:     validSessionIDNoUnique,
+			checkUniqueId: &uniqueId,
+			expectValid:   false,
+		},
+		{
+			name:          "Tampered signature",
+			sessionID:     strings.TrimSuffix(validSessionID, "A") + "B", // Change last character
+			checkUniqueId: &uniqueId,
+			expectValid:   false,
+		},
+		{
+			name:          "Invalid format - too few parts",
+			sessionID:     "onlyonepart",
+			checkUniqueId: nil,
+			expectValid:   false,
+		},
+		{
+			name:          "Invalid format - too many parts",
+			sessionID:     "too.many.parts.here",
+			checkUniqueId: nil,
+			expectValid:   false,
+		},
+		{
+			name:          "Empty session ID",
+			sessionID:     "",
+			checkUniqueId: nil,
+			expectValid:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := mgr.VerifySessionId(tc.sessionID, tc.checkUniqueId)
+
+			valid := err == nil
+			if valid != tc.expectValid {
+				t.Errorf("Expected valid=%v, got %v (err=%v)", tc.expectValid, valid, err)
+			}
+
+			if !tc.expectValid && err == nil {
+				t.Errorf("Expected error, got nil")
+			}
+
+			if tc.expectValid && err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+		})
+	}
+
+	// Test verification with a different secret key
+	err = differentMgr.VerifySessionId(validSessionID, &uniqueId)
+	if err == nil {
+		t.Error("Session ID should not validate with different secret key")
+	}
+}
+
+// Test end-to-end session creation and verification with multiple session managers
+func TestSessionIDManagerEndToEnd(t *testing.T) {
+	// Setup two managers with the same secret
+	const secret = "shared-secret-key"
+	mgr1 := NewSignedStatelessSessionManager(secret)
+	mgr2 := NewSignedStatelessSessionManager(secret)
+
+	// Generate session ID with first manager
+	uniqueId := "client123"
+	sessionID, err := mgr1.GenerateSessionId(&uniqueId)
+	if err != nil {
+		t.Fatalf("Failed to generate session ID: %v", err)
+	}
+
+	// Verify with second manager
+	err = mgr2.VerifySessionId(sessionID, &uniqueId)
+	if err != nil {
+		t.Errorf("Session ID generated by mgr1 should be valid for mgr2 with same secret: %v", err)
+	}
+
+	// Extract and check the random ID
+	//parts := strings.Split(sessionID, ".")
+	// if randomId != parts[0] {
+	//	t.Errorf("Expected randomId=%q, got %q", parts[0], randomId)
+	// }
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
To Say sessions in MCP are complex is an understatement. This change makes the cookie sessin id method no longer default, and adds a pre-flight capability where a sessionId can be included in a query string.