### PR TITLE
Removed PrincipalId From Session Gen on SSE

### DIFF
--- a/internal/httphandlers/sse_get_handler.go
+++ b/internal/httphandlers/sse_get_handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	actors2 "github.com/traego/scaled-mcp/internal/actors"
 	"github.com/traego/scaled-mcp/internal/channels"
-	"github.com/traego/scaled-mcp/pkg/auth"
 	"github.com/traego/scaled-mcp/pkg/utils"
 	"log/slog"
 	"net/http"
@@ -23,8 +22,6 @@ func (h *MCPHandler) HandleSSEGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *MCPHandler) HandleSessionPreFlight(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
 	// Set appropriate headers for the response
 	w.Header().Set("Content-Type", "application/json")
 
@@ -35,14 +32,8 @@ func (h *MCPHandler) HandleSessionPreFlight(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var uniqueId *string
-	if ai := auth.GetAuthInfo(ctx); ai != nil && h.serverInfo.GetAuthHandler() != nil {
-		uid := ai.GetPrincipalId()
-		uniqueId = &uid
-	}
-
 	// Generate a secure signed session ID that includes a random component and a signature
-	sessionID, err := h.serverInfo.GetSessionManager().GenerateSessionId(uniqueId)
+	sessionID, err := h.serverInfo.GetSessionManager().GenerateSessionId(nil)
 	if err != nil {
 		slog.Error("failed to generate session ID", slog.Any("error", err))
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -70,15 +61,11 @@ func (h *MCPHandler) HandleSessionPreFlight(w http.ResponseWriter, r *http.Reque
 	}
 }
 
+// SSEGetFunc handles the GET for SSE - one important note, SSE will NEVER have an auth header, so we explicitly do
+// not include unique IDs for sessionIds within the context of the SSE transport.
 func (h *MCPHandler) SSEGetFunc(w http.ResponseWriter, r *http.Request, basePath string) {
 	// I think this is easy...spin up the death watcher, spin up the connection watcher, wait for death to come
 	ctx := r.Context() // TODO Add logging details around these
-
-	var uniqueId *string
-	if ai := auth.GetAuthInfo(ctx); ai != nil && h.serverInfo.GetAuthHandler() != nil {
-		uid := ai.GetPrincipalId()
-		uniqueId = &uid
-	}
 
 	// To read the session_id cookie
 	cookie, err := r.Cookie("session_id")
@@ -94,16 +81,9 @@ func (h *MCPHandler) SSEGetFunc(w http.ResponseWriter, r *http.Request, basePath
 		if r.URL.Query().Get("sessionId") != "" {
 			// If session ID is provided in the query string, verify it's a valid signed ID
 			sessionId = r.URL.Query().Get("sessionId")
-
-			// Verify the signed session ID with a 15-minute max age
-			err = h.serverInfo.GetSessionManager().VerifySessionId(sessionId, uniqueId)
-			if err != nil {
-				http.Error(w, "Access denied", http.StatusForbidden)
-			}
-			// Use the verified random ID component
 			setCookie = false
 		} else {
-			sessionId, err = h.serverInfo.GetSessionManager().GenerateSessionId(uniqueId)
+			sessionId, err = h.serverInfo.GetSessionManager().GenerateSessionId(nil)
 			if err != nil {
 				handleError(w, err, "")
 				return
@@ -111,6 +91,12 @@ func (h *MCPHandler) SSEGetFunc(w http.ResponseWriter, r *http.Request, basePath
 		}
 	} else {
 		sessionId = cookie.Value
+	}
+
+	// Verify the sessionId
+	err = h.serverInfo.GetSessionManager().VerifySessionId(sessionId, nil)
+	if err != nil {
+		http.Error(w, "Access denied", http.StatusForbidden)
 	}
 
 	san := utils.GetSessionActorName(sessionId)


### PR DESCRIPTION
SSE get commands will inconsistently and generally NOT push through authorization headers correctly, so the session preflight that used the auth header created a sessionId we couldn't later validate. Fixed.